### PR TITLE
fix: add remote environment staging

### DIFF
--- a/jx-requirements.yml
+++ b/jx-requirements.yml
@@ -37,7 +37,9 @@ environments:
       enabled: false
       production: false
   key: staging
-  repository: environment-bootv22-staging
+  owner: cb-kubecd
+  remoteCluster: true
+  repository: environment-bootv3-staging5
 - ingress:
     domain: ""
     externalDNS: false


### PR DESCRIPTION
adds a link to the new remote environment git repository at https://github.com/cb-kubecd/environment-bootv3-staging5